### PR TITLE
Add python3 compatability

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -16,13 +16,13 @@ package: datapoint-python
 
 ## The platforms to build on.
 ## platform defaults to linux-64 
-# platform: 
-#  - linux-64
+ platform: 
+  - linux-64
 #  - linux-32
 ## The engine are the inital conda packages you want to run with 
-# engine:
-#  - python=2
-#  - python=3
+ engine:
+  - python=2
+  - python=3
 ## The env param is an environment variable list 
 # env:
 #  - MY_ENV=A CC=gcc
@@ -39,7 +39,7 @@ package: datapoint-python
 #   - echo "before_script!"
 ## Put your main computations here!  
 script:
-  - echo "This is my binstar build!"
+  - conda build .
 ## This will run after the script regardless of the result of script
 ## BINSTAR_BUILD_RESULT=[succcess|failure] 
 # after_script:
@@ -63,5 +63,5 @@ script:
 ## The special build targets 'conda' and 'pypi' may be used to 
 ## upload conda builds  
 ## e.g. conda is an alias for /opt/anaconda/conda-bld/<os-arch>/*.tar.bz2
-# build_targets:
-#   - conda
+build_targets:
+  - conda

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -16,11 +16,11 @@ package: datapoint-python
 
 ## The platforms to build on.
 ## platform defaults to linux-64 
- platform: 
+platform: 
   - linux-64
 #  - linux-32
 ## The engine are the inital conda packages you want to run with 
- engine:
+engine:
   - python=2
   - python=3
 ## The env param is an environment variable list 

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -39,7 +39,7 @@ engine:
 #   - echo "before_script!"
 ## Put your main computations here!  
 script:
-  - conda build .
+  - conda build --py all .
 ## This will run after the script regardless of the result of script
 ## BINSTAR_BUILD_RESULT=[succcess|failure] 
 # after_script:

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,67 @@
+
+## The package attribute specifies a binstar package namespace to build the package to. 
+## This can be specified here or on the command line
+package: datapoint-python
+
+## You can also specify the account to upload to,
+## you must be an admin of that account, this 
+## defaults to your user account
+# user: USERNAME 
+
+#===============================================================================
+# Build Matrix Options
+# These options may be a single item, a list or empty
+# The resulting number of builds is [platform * engine * env] 
+#===============================================================================
+
+## The platforms to build on.
+## platform defaults to linux-64 
+# platform: 
+#  - linux-64
+#  - linux-32
+## The engine are the inital conda packages you want to run with 
+# engine:
+#  - python=2
+#  - python=3
+## The env param is an environment variable list 
+# env:
+#  - MY_ENV=A CC=gcc
+#  - MY_ENV=B
+
+#===============================================================================
+# Script options
+# These options may be broken out into the before_script, script and after_script
+# or not, that is up to you 
+#===============================================================================
+
+## Run before the script
+# before_script:
+#   - echo "before_script!"
+## Put your main computations here!  
+script:
+  - echo "This is my binstar build!"
+## This will run after the script regardless of the result of script
+## BINSTAR_BUILD_RESULT=[succcess|failure] 
+# after_script:
+#   - echo "The build was a $BINSTAR_BUILD_RESULT" | tee artifact1.txt
+## This will be run only after a successful build
+# after_success:
+#   - echo "after_success!"
+## This will be run only after a build failure
+# after_failure:
+#   - echo "after_failure!"
+
+#===============================================================================
+# Build Results
+# Build results are split into two categories: artifacts and targets
+# You may omit either key and stiff have a successful build
+# They may be a string, list and contain any bash glob
+#===============================================================================
+
+## Build Targets: Upload these files to your binstar package
+## build targets may be a list of files (globs allows) to upload
+## The special build targets 'conda' and 'pypi' may be used to 
+## upload conda builds  
+## e.g. conda is an alias for /opt/anaconda/conda-bld/<os-arch>/*.tar.bz2
+# build_targets:
+#   - conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,17 @@ install:
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
 # TODO: Switch to own channel
-- conda config --add channels IOOS # Appdirs py27, py33, py34, py35
+- conda config --add channels IOOS  # Appdirs py27, py33, py34, py35
+- conda config --add channels pypi  # Needed for requests 2.3.0 for py3.5
 - conda update -q conda
 - conda info -a
 
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
 - conda install -n test-environment --file requirements.txt
-- conda install -n test-environment pylint pip nose
+- conda install -n test-environment pylint nose conda-build
+- conda build .
+- conda install -n test-environment --use-local datapoint-python
 - source activate test-environment
-- pip install -e .
 
 script:
 - nosetests -w tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,12 @@ install:
 - source activate test-environment
 - conda install --file requirements.txt
 - conda install pylint
-- pip install .
+- pip install -e .
 
 script:
 - nosetests -w tests/unit
 - if [[ "$API_KEY" != "" ]]; then
-    nosetests -w tests/integration
+    nosetests -w tests/integration;
   fi
 - pylint -E datapoint
 # deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ install:
 - conda info -a
 
 - conda install conda-build
-- conda build --py $TRAVIS_PYTHON_VERSION .
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
 - conda install -n test-environment --file requirements.txt
 - conda install -n test-environment pylint nose 
 - conda install -n test-environment --use-local datapoint-python
 - source activate test-environment
+- python setup.py install
 
 script:
 - nosetests -w tests/unit
@@ -42,6 +42,8 @@ script:
     nosetests -w tests/integration;
   fi
 - pylint -E datapoint
+- conda build --py $TRAVIS_PYTHON_VERSION .
+- conda info datapoint-python
 # deploy:
 #   provider: pypi
 #   user: jacob.tomlinson

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,9 @@ install:
 - conda info -a
 
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+- conda install -n test-environment --file requirements.txt
+- conda install -n test-environment pylint pip
 - source activate test-environment
-- conda install --file requirements.txt
-- conda install pylint pip
-- which pip
 - pip install -e .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   fi
 - pylint -E datapoint
 - conda build --py $TRAVIS_PYTHON_VERSION .
-- conda info datapoint-python
+
 # deploy:
 #   provider: pypi
 #   user: jacob.tomlinson

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ install:
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
 - conda install -n test-environment --file requirements.txt
 - conda install -n test-environment pylint nose 
-- conda install -n test-environment --use-local datapoint-python
 - source activate test-environment
 - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   fi
 - bash miniconda.sh -b -p $HOME/miniconda
-- export PATh=$HOME/miniconda/bin:$PATH
+- export PATH=$HOME/miniconda/bin:$PATH
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
 - conda config -add channels faph  # TODO: Switch to own channel

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ install:
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
 - source activate test-environment
 - conda install --file requirements.txt
-- conda install pylint
+- conda install pylint pip
+- which pip
 - pip install -e .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,43 @@ language: python
 python:
 - '2.6'
 - '2.7'
+- '3.3'
 - '3.4'
-env:
-- secure: PEOM40L5TK78GFQyt2I2PgOFf8QYGcP0YZmgMhacuKnCI0Lr3wztXucWtxeVpXeuDDe12d349FumQrg6ard8T69ZZYe25eJ5lR9ZMyVOzFJ9Ew3XhoEgWBgKFRNjEkhFU+/reYWRBkYHyFImLe9d8wq1I2UMQ6z2189PLKfBtIg=
+- '3.5'
+# env:
+# - secure: PEOM40L5TK78GFQyt2I2PgOFf8QYGcP0YZmgMhacuKnCI0Lr3wztXucWtxeVpXeuDDe12d349FumQrg6ard8T69ZZYe25eJ5lR9ZMyVOzFJ9Ew3XhoEgWBgKFRNjEkhFU+/reYWRBkYHyFImLe9d8wq1I2UMQ6z2189PLKfBtIg=
 install:
+- sudo apt-get update
+- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+    wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+  else
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  fi
+- bash miniconda-sh -b -p $HOME/miniconda
+- export PATh=$HOME/miniconda/bin:$PATH
+- hash -r
+- conda config --set always_yes yes --set changeps1 no
+- conda config -add channels faph  # TODO: Switch to own channel
+- conda update -q conda
+- conda info -a
+
+- conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+- conda install -f requirements.txt
+- conda install pylint
 - pip install .
-- pip install pylint
-- pip install -r requirements.txt
+
 script:
 - nosetests -w tests/unit
-- nosetests -w tests/integration
+- if [[ "$API_KEY" != "" ]]; then
+    nosetests -w tests/integration
+  fi
 - pylint -E datapoint
-deploy:
-  provider: pypi
-  user: jacob.tomlinson
-  password:
-    secure: lxlsbRqzo7XTAtjbU8KlkEdB/foHJgtQ1lYBa147k0x4PTaoicGUffmqWOO6P8+qU3sBZTMxeMIyyNWY3aS9k1JrFi7UYkLxSTI50BG/atNPiNa3xnOVuFjj8i3hDfXudRmWcFtxZH+83yqQ5VzEesn1UNdnBV87jvHv9MviFrc=
-  on:
-    tags: true
-    all_branches: true
-    repo: jacobtomlinson/datapoint-python
+# deploy:
+#   provider: pypi
+#   user: jacob.tomlinson
+#   password:
+#     secure: lxlsbRqzo7XTAtjbU8KlkEdB/foHJgtQ1lYBa147k0x4PTaoicGUffmqWOO6P8+qU3sBZTMxeMIyyNWY3aS9k1JrFi7UYkLxSTI50BG/atNPiNa3xnOVuFjj8i3hDfXudRmWcFtxZH+83yqQ5VzEesn1UNdnBV87jvHv9MviFrc=
+#   on:
+#     tags: true
+#     all_branches: true
+#     repo: jacobtomlinson/datapoint-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ install:
 - export PATH=$HOME/miniconda/bin:$PATH
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
-- conda config --add channels faph  # TODO: Switch to own channel
+# TODO: Switch to own channel
+- conda config --add channels IOOS # Appdirs py27, py33, py34, py35
 - conda update -q conda
 - conda info -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 - conda info -a
 
 - conda install conda-build
-- conda build .
+- conda build --py $TRAVIS_PYTHON_VERSION .
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
 - conda install -n test-environment --file requirements.txt
 - conda install -n test-environment pylint nose 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
 # TODO: Switch to own channel
-- conda config --add channels IOOS  # Appdirs py27, py33, py34, py35
+- conda config --add channels bensec
 - conda config --add channels pypi  # Needed for requests 2.3.0 for py3.5
 - conda update -q conda
 - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
 - '2.6'
 - '2.7'
+- '3.4'
 env:
 - secure: PEOM40L5TK78GFQyt2I2PgOFf8QYGcP0YZmgMhacuKnCI0Lr3wztXucWtxeVpXeuDDe12d349FumQrg6ard8T69ZZYe25eJ5lR9ZMyVOzFJ9Ew3XhoEgWBgKFRNjEkhFU+/reYWRBkYHyFImLe9d8wq1I2UMQ6z2189PLKfBtIg=
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   else
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   fi
-- bash miniconda-sh -b -p $HOME/miniconda
+- bash miniconda.sh -b -p $HOME/miniconda
 - export PATh=$HOME/miniconda/bin:$PATH
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
@@ -23,7 +23,8 @@ install:
 - conda info -a
 
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-- conda install -f requirements.txt
+- source activate test-envrionment
+- conda install --file requirements.txt
 - conda install pylint
 - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ notifications:
   email: false
 
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+- if [[ "$TRAVIS_PYTHON_VERSION" == 2.* ]]; then
     wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
   else
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ python:
 - '3.5'
 # env:
 # - secure: PEOM40L5TK78GFQyt2I2PgOFf8QYGcP0YZmgMhacuKnCI0Lr3wztXucWtxeVpXeuDDe12d349FumQrg6ard8T69ZZYe25eJ5lR9ZMyVOzFJ9Ew3XhoEgWBgKFRNjEkhFU+/reYWRBkYHyFImLe9d8wq1I2UMQ6z2189PLKfBtIg=
+
+notifications:
+  email: false
+
 install:
 - sudo apt-get update
 - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -24,10 +28,11 @@ install:
 - conda update -q conda
 - conda info -a
 
+- conda install conda-build
+- conda build .
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
 - conda install -n test-environment --file requirements.txt
-- conda install -n test-environment pylint nose conda-build
-- conda build .
+- conda install -n test-environment pylint nose 
 - conda install -n test-environment --use-local datapoint-python
 - source activate test-environment
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
 - conda install -n test-environment --file requirements.txt
-- conda install -n test-environment pylint pip
+- conda install -n test-environment pylint pip nose
 - source activate test-environment
 - pip install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 - conda info -a
 
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-- source activate test-envrionment
+- source activate test-environment
 - conda install --file requirements.txt
 - conda install pylint
 - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 - export PATH=$HOME/miniconda/bin:$PATH
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
-- conda config -add channels faph  # TODO: Switch to own channel
+- conda config --add channels faph  # TODO: Switch to own channel
 - conda update -q conda
 - conda info -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
 - '2.6'
 - '2.7'
@@ -12,7 +13,6 @@ notifications:
   email: false
 
 install:
-- sudo apt-get update
 - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
     wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
   else

--- a/conda.yaml
+++ b/conda.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.2.3" %}
+
+package:
+    name: datapoint-python
+    version: {{version}}
+
+source:
+    # git_url: https://github.com/jacobtomlinson/datapoint-python.git
+    # git_rev: v{{version}}
+    path: .
+
+build:
+    script: python setup.py install
+    number: 1
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - requests #==2.3.0
+        - appdirs  # Currently available in channel "faph"
+        - pytz
+
+test:
+    imports:
+        - datapoint
+    requires:
+        - nose
+        - pylint <1.4 # [py26]
+        - pylint # [not py26]
+    commands:
+        - pylint -E datapoint
+        - nosetests -w  $RECIPE_DIR/tests/unit
+        # Integration tests need the API_KEY
+
+
+about:
+    home: https://github.com/jacobtomlinson/datapoint-python
+    license: TBC

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -4,6 +4,7 @@ Datapoint python module
 
 from datetime import datetime
 from datetime import timedelta
+import sys
 from time import time
 import pytz
 
@@ -14,6 +15,10 @@ from .Forecast import Forecast
 from .Day import Day
 from .Timestep import Timestep
 from .Element import Element
+
+if (sys.version_info > (3, 0)):
+    long = int
+
 
 API_URL = "http://datapoint.metoffice.gov.uk/public/data/val/wxfcs/all/json"
 DATE_FORMAT = "%Y-%m-%dZ"

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -22,6 +22,7 @@ if (sys.version_info > (3, 0)):
 
 API_URL = "http://datapoint.metoffice.gov.uk/public/data/val/wxfcs/all/json"
 DATE_FORMAT = "%Y-%m-%dZ"
+DATA_DATE_FORMAT = "%Y-%m-%dT%XZ"
 ELEMENTS = {
     "Day":
         {"U":"U", "V":"V", "W":"W", "T":"Dm", "S":"S", "Pp":"PPd",
@@ -205,7 +206,8 @@ class Manager(object):
         params = data['SiteRep']['Wx']['Param']
 
         forecast = Forecast()
-        forecast.data_date = datetime.strptime(data['SiteRep']['DV']['dataDate'], DATE_FORMAT).replace(tzinfo=pytz.UTC)
+        forecast.data_date = data['SiteRep']['DV']['dataDate']
+        forecast.data_date = datetime.strptime(data['SiteRep']['DV']['dataDate'], DATA_DATE_FORMAT).replace(tzinfo=pytz.UTC)
         forecast.continent = data['SiteRep']['DV']['Location']['continent']
         forecast.country = data['SiteRep']['DV']['Location']['country']
         forecast.name = data['SiteRep']['DV']['Location']['name']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.3.0
+requests
 appdirs
 pytz

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,6 @@ Currently under decision.
           'Development Status :: 3 - Alpha',
           'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.4',
       ]
      )

--- a/tests/integration/manager_test.py
+++ b/tests/integration/manager_test.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from types import *
 from nose.tools import *
@@ -13,3 +14,92 @@ class TestManager:
         site = self.manager.get_nearest_site(-0.124626, 51.500728)
         assert site.name == 'London'
 
+    def test_get_all_sites(self):
+        sites = self.manager.get_all_sites()
+        assert isinstance(sites, list)
+        assert sites
+
+    def test_get_daily_forecast(self):
+        site = self.manager.get_nearest_site(-0.124626, 51.500728)
+        forecast = self.manager.get_forecast_for_site(site.id, 'daily')
+        assert isinstance(forecast, datapoint.Forecast.Forecast)
+        assert forecast.continent.upper() == 'EUROPE'
+        assert forecast.country.upper() == 'ENGLAND'
+        assert forecast.name.upper() == 'LONDON'
+        assert abs(float(forecast.longitude) - (-0.124626)) < 0.1
+        assert abs(float(forecast.latitude) - 51.500728) < 0.1
+        # Forecast should have been made within last 3 hours
+        tz = forecast.data_date.tzinfo
+        assert (forecast.data_date 
+            - datetime.datetime.now(tz=tz) < datetime.timedelta(hours=3))
+        # First forecast should be less than 12 hours away
+        tz = forecast.days[0].timesteps[0].date.tzinfo
+        assert (forecast.days[0].timesteps[0].date - 
+            datetime.datetime.now(tz=tz) < datetime.timedelta(hours=12))
+        for day in forecast.days:
+            for timestep in day.timesteps:
+                assert timestep.name in ['Day', 'Night']
+                assert self.manager._weather_to_text(
+                    int(timestep.weather.value)) == timestep.weather.text
+                assert -100 < timestep.temperature.value < 100
+                assert timestep.temperature.units == 'C'
+                assert -100 < timestep.feels_like_temperature.value < 100
+                assert timestep.feels_like_temperature.units == 'C'
+                assert 0 <= timestep.wind_speed.value < 300
+                assert timestep.wind_speed.units == 'mph'
+                for char in timestep.wind_direction.value:
+                    assert char in ['N', 'E', 'S', 'W']
+                assert timestep.wind_direction.units == 'compass'
+                assert 0 <= timestep.wind_gust.value < 300
+                assert timestep.wind_gust.units == 'mph'
+                assert (timestep.visibility.value in 
+                    ['UN', 'VP', 'PO', 'MO', 'GO', 'VG', 'EX'])
+                assert 0 <= timestep.precipitation.value <= 100
+                assert timestep.precipitation.units == '%'
+                assert 0 <= timestep.humidity.value <= 100
+                assert timestep.humidity.units == '%'
+                if hasattr(timestep.uv, 'value'):
+                    assert 0 < int(timestep.uv.value) < 20
+
+    def test_get_3hour_forecast(self):
+        site = self.manager.get_nearest_site(-0.124626, 51.500728)
+        forecast = self.manager.get_forecast_for_site(site.id, '3hourly')
+        assert isinstance(forecast, datapoint.Forecast.Forecast)
+        assert forecast.continent.upper() == 'EUROPE'
+        assert forecast.country.upper() == 'ENGLAND'
+        assert forecast.name.upper() == 'LONDON'
+        assert abs(float(forecast.longitude) - (-0.124626)) < 0.1
+        assert abs(float(forecast.latitude) - 51.500728) < 0.1
+        # Forecast should have been made within last 3 hours
+        tz = forecast.data_date.tzinfo
+        assert (forecast.data_date 
+            - datetime.datetime.now(tz=tz) < datetime.timedelta(hours=3))
+        # First forecast should be less than 12 hours away
+        tz = forecast.days[0].timesteps[0].date.tzinfo
+        assert (forecast.days[0].timesteps[0].date - 
+            datetime.datetime.now(tz=tz) < datetime.timedelta(hours=3))
+        for day in forecast.days:
+            for timestep in day.timesteps:
+                assert isinstance(timestep.name, int)
+                assert self.manager._weather_to_text(
+                    int(timestep.weather.value)) == timestep.weather.text
+                assert -100 < timestep.temperature.value < 100
+                assert timestep.temperature.units == 'C'
+                assert -100 < timestep.feels_like_temperature.value < 100
+                assert timestep.feels_like_temperature.units == 'C'
+                assert 0 <= timestep.wind_speed.value < 300
+                assert timestep.wind_speed.units == 'mph'
+                for char in timestep.wind_direction.value:
+                    assert char in ['N', 'E', 'S', 'W']
+                assert timestep.wind_direction.units == 'compass'
+                assert 0 <= timestep.wind_gust.value < 300
+                assert timestep.wind_gust.units == 'mph'
+                assert (timestep.visibility.value in 
+                    ['UN', 'VP', 'PO', 'MO', 'GO', 'VG', 'EX'])
+                assert 0 <= timestep.precipitation.value <= 100
+                assert timestep.precipitation.units == '%'
+                assert 0 <= timestep.humidity.value <= 100
+                assert timestep.humidity.units == '%'
+                if hasattr(timestep.uv, 'value'):
+                    print(timestep.uv.value)
+                    assert 0 <= int(timestep.uv.value) < 20

--- a/tests/integration/manager_test.py
+++ b/tests/integration/manager_test.py
@@ -101,5 +101,4 @@ class TestManager:
                 assert 0 <= timestep.humidity.value <= 100
                 assert timestep.humidity.units == '%'
                 if hasattr(timestep.uv, 'value'):
-                    print(timestep.uv.value)
                     assert 0 <= int(timestep.uv.value) < 20

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -10,7 +10,7 @@ class TestManager:
 
     def test_weather_to_text_is_string(self):
         weather_text = self.manager._weather_to_text(0)
-        assert type(weather_text) is StringType
+        assert isinstance(weather_text, type(""))
 
     @raises(ValueError)
     def test_weather_to_text_invalid_input_None(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,0 @@
-[tox]
-envlist = py27,py34
-
-[testenv]
-passenv = API_KEY
-deps = 
-    -r{toxinidir}/requirements.txt
-    nose
-commands = nosetests tests/unit tests/integration

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py34
+
+[testenv]
+passenv = API_KEY
+deps = 
+    -r{toxinidir}/requirements.txt
+    nose
+commands = nosetests tests/unit tests/integration


### PR DESCRIPTION
This makes minor changes that are needed for py3 compatibility

* :type:`long` does not exist in py3, so is aliased to :type:`int` when running under py3
* `StringType` does not exist in py3, instead an `isinstance()` check is used.
* Add `tox.ini` to facilitate testing on both py2 and py3