### PR TITLE
Fix forecast.now() not working

### DIFF
--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -20,8 +20,6 @@ class Forecast(object):
         """
         now = None
         d = datetime.datetime.utcnow()
-        print(d)
-        print(self.days[0].date.strftime("%Y-%m-%dZ"))
         msm = (d - d.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds() / 60
         if self.days[0].date.strftime("%Y-%m-%dZ") == d.strftime("%Y-%m-%dZ"):
             for timestep in self.days[0].timesteps:
@@ -30,4 +28,5 @@ class Forecast(object):
                 now = timestep
             return now
         else:
-            return False
+#            return False
+             return(d, self.days[0].date.strftime("%Y-%m-%dZ"))

--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -20,6 +20,8 @@ class Forecast(object):
         """
         now = None
         d = datetime.datetime.utcnow()
+        print(d)
+        print(self.days[0].date.strftime("%Y-%m-%dZ"))
         msm = (d - d.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds() / 60
         if self.days[0].date.strftime("%Y-%m-%dZ") == d.strftime("%Y-%m-%dZ"):
             for timestep in self.days[0].timesteps:

--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -1,4 +1,5 @@
 import datetime
+import sys
 
 class Forecast(object):
     def __init__(self, api_key=""):
@@ -14,13 +15,23 @@ class Forecast(object):
         self.elevation = None
         self.days = []
 
+    def timedelta_total_seconds(self, timedelta):
+        return (
+            timedelta.microseconds + 0.0 +
+            (timedelta.seconds + timedelta.days * 24 * 3600) * 10 ** 6) / 10 ** 6
+
     def now(self):
         """
         Function to return just the current timestep from this forecast
         """
         now = None
         d = datetime.datetime.utcnow()
-        msm = (d - d.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds() / 60
+        for_total_seconds = d - d.replace(hour=0, minute=0, second=0, microsecond=0)
+        # python 2.6 does not have timedelta.total_seconds()
+        if sys.version_info < (2,7):
+            msm = timedelta_total_seconds(for_total_seconds) / 60
+        else:
+            msm = for_total_seconds.total_seconds() / 60
         if self.days[0].date.strftime("%Y-%m-%dZ") == d.strftime("%Y-%m-%dZ"):
             for timestep in self.days[0].timesteps:
                 if timestep.name > msm:

--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -29,7 +29,7 @@ class Forecast(object):
         for_total_seconds = d - d.replace(hour=0, minute=0, second=0, microsecond=0)
         # python 2.6 does not have timedelta.total_seconds()
         if sys.version_info < (2,7):
-            msm = timedelta_total_seconds(for_total_seconds) / 60
+            msm = self.timedelta_total_seconds(for_total_seconds) / 60
         else:
             msm = for_total_seconds.total_seconds() / 60
         if self.days[0].date.strftime("%Y-%m-%dZ") == d.strftime("%Y-%m-%dZ"):

--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -21,12 +21,11 @@ class Forecast(object):
         now = None
         d = datetime.datetime.utcnow()
         msm = (d - d.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds() / 60
-        if self.days[0].date == d.strftime("%Y-%m-%dZ"):
+        if self.days[0].date.strftime("%Y-%m-%dZ") == d.strftime("%Y-%m-%dZ"):
             for timestep in self.days[0].timesteps:
                 if timestep.name > msm:
                     break
                 now = timestep
             return now
         else:
-#            return False
-             return(d, self.days[0].date.strftime("%Y-%m-%dZ"))
+            return False

--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -21,7 +21,7 @@ class Forecast(object):
         now = None
         d = datetime.datetime.utcnow()
         msm = (d - d.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds() / 60
-        if self.days[0].date == d.strftime("%Y-%m-%dZ"):
+        if self.days[0].date.strftime("%Y-%m-%dZ") == d.strftime("%Y-%m-%dZ"):
             for timestep in self.days[0].timesteps:
                 if timestep.name > msm:
                     break

--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -21,7 +21,7 @@ class Forecast(object):
         now = None
         d = datetime.datetime.utcnow()
         msm = (d - d.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds() / 60
-        if self.days[0].date.strftime("%Y-%m-%dZ") == d.strftime("%Y-%m-%dZ"):
+        if self.days[0].date == d.strftime("%Y-%m-%dZ"):
             for timestep in self.days[0].timesteps:
                 if timestep.name > msm:
                     break

--- a/tests/unit/forecast_test.py
+++ b/tests/unit/forecast_test.py
@@ -23,3 +23,6 @@ class TestForecast:
         
         self.forecast.days.append(test_day)        
         assert self.forecast.now()
+
+    def test_timedelta_works(self):
+        return

--- a/tests/unit/forecast_test.py
+++ b/tests/unit/forecast_test.py
@@ -23,6 +23,3 @@ class TestForecast:
         
         self.forecast.days.append(test_day)        
         assert self.forecast.now()
-
-    def test_timedelta_works(self):
-        return

--- a/tests/unit/forecast_test.py
+++ b/tests/unit/forecast_test.py
@@ -1,0 +1,25 @@
+from types import *
+from nose.tools import *
+
+import datetime
+
+import datapoint
+
+
+
+class TestForecast:
+
+    def __init__(self):
+        self.forecast = datapoint.Forecast.Forecast()
+
+    def test_forecast_now_works(self):
+        test_day = datapoint.Day.Day()
+        test_day.date = datetime.datetime.utcnow()
+        
+        test_timestep = datapoint.Timestep.Timestep()
+        test_timestep.name = 1
+        
+        test_day.timesteps.append(test_timestep)        
+        
+        self.forecast.days.append(test_day)        
+        assert self.forecast.now()


### PR DESCRIPTION
I was trying to work through your example using this code:

```
# Get the current timestep from the forecast
current_timestep = forecast.now()

# Print out the site and current weather
print site.name, "-", current_timestep.weather.text

```

and getting an error as forecast.now() would always return False, and not a timestep object.

It looked to me like the problem was the if statement was comparing two different types, so would never be True.

This fix seems to get the example working for me.

My Python version is: Python 3.5.2 |Anaconda 4.1.1 (64-bit)| (default, Jul  5 2016, 11:41:13) [MSC v.1900 64 bit (AMD64)]
