### PR TITLE
Swaps latitude and longitude

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The author will make reasonable efforts to keep it up to date and fully featured
 
 ## Features
  * List forecast sites
- * Get nearest forecast site from longitude and latitiude
+ * Get nearest forecast site from latitiude and longitude
  * Get the following 5 day forecast types for any site
   * Daily (Two timesteps, midday and midnight UTC)
   * 3 hourly (Eight timesteps, every 3 hours starting at midnight UTC)
@@ -42,8 +42,8 @@ import datapoint
 # Create connection to DataPoint with your API key
 conn = datapoint.connection(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
-# Get the nearest site for my longitude and latitude
-site = conn.get_nearest_site(-0.124626, 51.500728)
+# Get the nearest site for my latitude and longitude
+site = conn.get_nearest_site(51.500728, -0.124626)
 
 # Get a forecast for my nearest site with 3 hourly timesteps
 forecast = conn.get_forecast_for_site(site.id, "3hourly")

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -174,7 +174,7 @@ class Manager(object):
 
         return sites
 
-    def get_nearest_site(self, longitude=False, latitude=False):
+    def get_nearest_site(self, latitude=False,  longitude=False):
         """
         This function returns the nearest Site object to the specified
         coordinates.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,12 +31,12 @@ So now that we have our Manager Object with a connection to DataPoint we can req
 some data. Our goal is to request some forecast data but first we need to know the
 site ID for the location we want data for. Luckily the Manager Object has a method
 to return a [Site Object](objects.md#site), which contains the ID among other things,
-from a specified longitude and latitude.
+from a specified latitude and longitude.
 
 We can simply request a Site Object like so:
 
 ```
-site = conn.get_nearest_site(-0.124626, 51.500728)
+site = conn.get_nearest_site(51.500728, -0.124626)
 ```
 
 For now we're just going to use this object to get us our forecast but you'll find

--- a/docs/objects.md
+++ b/docs/objects.md
@@ -46,10 +46,10 @@ The object which stores your API key and has methods to access the API.
 Returns a list of all available sites.<br/>
 returns: list of Site objects
 
-##### get_nearest_site(longitude=False, latitude=False)
+##### get_nearest_site(latitude=False, longitude=False)
 Returns the nearest Site object to the specified coordinates.<br/>
-param longitude: int or float<br/>
 param latitude: int or float<br/>
+param longitude: int or float<br/>
 returns: Site
 
 ##### get_forecast_for_site(site_id, frequency="daily"):
@@ -142,11 +142,11 @@ An object with properties of a single forecast and a list of Day objects.
 <td>unicode</td>
 </tr>
 <tr>
-<td><b>longitude</b></td>
+<td><b>latitude</b></td>
 <td>unicode</td>
 </tr>
 <tr>
-<td><b>latitude</b></td>
+<td><b>longitude</b></td>
 <td>unicode</td>
 </tr>
 <tr>

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,20 +6,20 @@
 _Examples of getting data from DataPoint._
 
 * [Current Weather](current_weather/) - Get the current weather for a specified
-longitude and latitude.
+latitude and longitude.
 
 * [Simple Forecast](simple_forecast/) - Get a full 5 day forecast for a specified
-longitude and latitude.
+latitude and longitude.
 
 ## Making Decisions
 
 _Examples which make decisions based on weather data._
 
 * [Umbrella](umbrella/) - Inform the user whether they need an umbrella today
-for a specified longitude and latitude.
+for a specified latitude and longitude.
 
 * [Washing](washing/) - Inform the user which day in the next 5 days would be
-the best for hanging out their washing for a specified longitude and latitude.
+the best for hanging out their washing for a specified latitude and longitude.
 
 ## Mixing Data
 
@@ -30,4 +30,4 @@ take the tube across London, based on weather and tube service for two sets of
 longitude and latitude along with a tube line name.
 
 * [Postcodes](postcodes_to_lat_lng) - A variation on the [Current Weather](current_weather/)
-example but uses UK postcodes instead of longitude and latitude.
+example but uses UK postcodes instead of latitude and longitude.

--- a/examples/current_weather/current_weather.py
+++ b/examples/current_weather/current_weather.py
@@ -10,7 +10,7 @@ import datapoint
 conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
 # Get nearest site and print out its name
-site = conn.get_nearest_site(-0.124626, 51.500728)
+site = conn.get_nearest_site(51.500728, -0.124626)
 print site.name
 
 # Get a forecast for the nearest site

--- a/examples/postcodes_to_lat_lng/postcodes_to_lat_lng.py
+++ b/examples/postcodes_to_lat_lng/postcodes_to_lat_lng.py
@@ -9,14 +9,14 @@ import postcodes
 # Create datapoint connection
 conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
-# Get longitude and latitude from postcode
+# Get latitude and longitude from postcode
 pc = postcodes.PostCoder()
 result = pc.get('SW1A 2AA')
 latitude = result['geo']['lat']
 longitude = result['geo']['lng']
 
 # Get nearest site and print out its name
-site = conn.get_nearest_site(longitude, latitude)
+site = conn.get_nearest_site(latitude, longitude)
 print site.name
 
 # Get a forecast for the nearest site

--- a/examples/simple_forecast/simple_forecast.py
+++ b/examples/simple_forecast/simple_forecast.py
@@ -10,7 +10,7 @@ import datapoint
 conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
 # Get nearest site and print out its name
-site = conn.get_nearest_site(-0.124626, 51.500728)
+site = conn.get_nearest_site(51.500728, -0.124626)
 print site.name
 
 # Get a forecast for the nearest site

--- a/examples/tube_bike/tube_bike.py
+++ b/examples/tube_bike/tube_bike.py
@@ -12,8 +12,8 @@ import tubestatus
 conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
 # Get nearest site to my house and to work
-my_house = conn.get_nearest_site(0.0057500, 51.5016730)
-work = conn.get_nearest_site(-0.1123050, 51.5031650)
+my_house = conn.get_nearest_site(51.5016730, 0.0057500)
+work = conn.get_nearest_site(51.5031650, -0.1123050)
 
 # Get a forecast for my house and work
 my_house_forecast = conn.get_forecast_for_site(my_house.id, "3hourly")

--- a/examples/umbrella/umbrella.py
+++ b/examples/umbrella/umbrella.py
@@ -13,7 +13,7 @@ umbrella = False
 conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
 # Get nearest site and print out its name
-site = conn.get_nearest_site(-0.124626, 51.500728)
+site = conn.get_nearest_site(51.500728, -0.124626)
 print site.name
 
 # Get a forecast for the nearest site

--- a/examples/washing/washing.py
+++ b/examples/washing/washing.py
@@ -23,7 +23,7 @@ best_day_score = 0 # For simplicity the score will be temperature + wind speed
 conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
 # Get nearest site and print out its name
-site = conn.get_nearest_site(-0.124626, 51.500728)
+site = conn.get_nearest_site(51.500728, -0.124626)
 print site.name
 
 # Get a forecast for the nearest site

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ Features
 --------
 
 -  List forecast sites
--  Get nearest forecast site from longitude and latitiude
+-  Get nearest forecast site from latitiude and longitude
 -  Get the following 5 day forecast types for any site
 -  Daily (Two timesteps, midday and midnight UTC)
 -  3 hourly (Eight timesteps, every 3 hours starting at midnight UTC)

--- a/tests/integration/manager_test.py
+++ b/tests/integration/manager_test.py
@@ -11,7 +11,7 @@ class TestManager:
         self.manager = datapoint.Manager(api_key=os.environ['API_KEY'])
 
     def test_site(self):
-        site = self.manager.get_nearest_site(-0.124626, 51.500728)
+        site = self.manager.get_nearest_site(51.500728, -0.124626)
         assert site.name == 'London'
 
     def test_get_all_sites(self):
@@ -20,14 +20,14 @@ class TestManager:
         assert sites
 
     def test_get_daily_forecast(self):
-        site = self.manager.get_nearest_site(-0.124626, 51.500728)
+        site = self.manager.get_nearest_site(51.500728, -0.124626)
         forecast = self.manager.get_forecast_for_site(site.id, 'daily')
         assert isinstance(forecast, datapoint.Forecast.Forecast)
         assert forecast.continent.upper() == 'EUROPE'
         assert forecast.country.upper() == 'ENGLAND'
         assert forecast.name.upper() == 'LONDON'
-        assert abs(float(forecast.longitude) - (-0.124626)) < 0.1
         assert abs(float(forecast.latitude) - 51.500728) < 0.1
+        assert abs(float(forecast.longitude) - (-0.124626)) < 0.1
         # Forecast should have been made within last 3 hours
         tz = forecast.data_date.tzinfo
         assert (forecast.data_date
@@ -62,14 +62,14 @@ class TestManager:
                     assert 0 < int(timestep.uv.value) < 20
 
     def test_get_3hour_forecast(self):
-        site = self.manager.get_nearest_site(-0.124626, 51.500728)
+        site = self.manager.get_nearest_site(51.500728, -0.124626)
         forecast = self.manager.get_forecast_for_site(site.id, '3hourly')
         assert isinstance(forecast, datapoint.Forecast.Forecast)
         assert forecast.continent.upper() == 'EUROPE'
         assert forecast.country.upper() == 'ENGLAND'
         assert forecast.name.upper() == 'LONDON'
-        assert abs(float(forecast.longitude) - (-0.124626)) < 0.1
         assert abs(float(forecast.latitude) - 51.500728) < 0.1
+        assert abs(float(forecast.longitude) - (-0.124626)) < 0.1
         # Forecast should have been made within last 3 hours
         tz = forecast.data_date.tzinfo
         assert (forecast.data_date


### PR DESCRIPTION
Fixes #16 
I've quickly refactored through and swapped latitude and longitude in all places I could find. As shown [here](https://books.google.com/ngrams/graph?content=latitude+longitude%2C+longitude+latitude&case_insensitive=on&year_start=1800&year_end=2000&corpus=15&smoothing=3&share=&direct_url=t4%3B%2Clatitude%20longitude%3B%2Cc0%3B%2Cs0%3B%3BLatitude%20Longitude%3B%2Cc0%3B%3Blatitude%20longitude%3B%2Cc0%3B%3BLATITUDE%20LONGITUDE%3B%2Cc0%3B%3BLatitude%20longitude%3B%2Cc0%3B%3Blatitude%20Longitude%3B%2Cc0%3B.t4%3B%2Clongitude%20latitude%3B%2Cc0%3B%2Cs0%3B%3BLongitude%20Latitude%3B%2Cc0%3B%3Blongitude%20latitude%3B%2Cc0%3B%3Blongitude%20Latitude%3B%2Cc0%3B%3BLONGITUDE%20LATITUDE%3B%2Cc0%3B%3BLONGITUDE%20Latitude%3B%2Cc0), latitude and longitude are more commonly written as such.

(Apologies for inconsistent commit message tense, I typed them on autopilot)