### PR TITLE
Change print statements in Manager.py and Forecast.py to python3 style

### DIFF
--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -82,5 +82,5 @@ class Forecast(object):
                     future = timestep
                     return future
         else:
-            print 'ERROR: requested date is outside the forcast range selected,', len(self.days)
+            print('ERROR: requested date is outside the forecast range selected,' + str(len(self.days)))
             return False

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -180,7 +180,7 @@ class Manager(object):
         coordinates.
         """
         if not longitude or not latitude:
-            print 'ERROR: No longitude and latitude given.'
+            print('ERROR: No longitude and latitude given.')
             return False
 
         nearest = False


### PR DESCRIPTION
There were two print statements in Forecast.py and Manager.py using python2
style print statements (without parentheses). This causes errors during
installation in python3.6 and python3.7 on Arch Linux.

Also fixed a typo in the print statement in Forecast.py

This pull request fixes #38 