### PR TITLE
Fix issue #40 by reverting forecast.now() return logic

### DIFF
--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -37,8 +37,9 @@ class Forecast(object):
             for timestep in self.days[0].timesteps:                
                 if timestep.name > msm:
                     #print timestep.date,timestep.name,msm
-                    now = timestep
-                    return now
+                    break
+                now = timestep
+            return now
         else:
             return False
 

--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -34,7 +34,7 @@ class Forecast(object):
         else:
             msm = for_total_seconds.total_seconds() / 60
         if self.days[0].date.strftime("%Y-%m-%dZ") == d.strftime("%Y-%m-%dZ"):
-            for timestep in self.days[0].timesteps:                
+            for timestep in self.days[0].timesteps:
                 if timestep.name > msm:
                     #print timestep.date,timestep.name,msm
                     break


### PR DESCRIPTION
This commit reverts the return logic in forecast.now() to the state it was in f3098389fd03642bb2dc7d1242e8cefd70f37937. The function now returns a timestep object, and the unit test for forecast passes.