### PR TITLE
Fix error which sets sites to none

### DIFF
--- a/datapoint/Forecast.py
+++ b/datapoint/Forecast.py
@@ -34,11 +34,12 @@ class Forecast(object):
         else:
             msm = for_total_seconds.total_seconds() / 60
         if self.days[0].date.strftime("%Y-%m-%dZ") == d.strftime("%Y-%m-%dZ"):
-            for timestep in self.days[0].timesteps:                
+            for timestep in self.days[0].timesteps:
                 if timestep.name > msm:
                     #print timestep.date,timestep.name,msm
-                    now = timestep
-                    return now
+                    break
+                now = timestep
+            return now
         else:
             return False
 

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -144,13 +144,7 @@ class Manager(object):
         """
 
         time_now = time()
-        print('sites_last_update = '+ str(self.sites_last_update))
-        print('sites_update_time = '+ str(self.sites_update_time))
-        print('time_now = ' + str(time_now))
-        print('time_now - self.sites_last_update = ' + str(time_now - self.sites_last_update))
-        num_sites = 0
         if (time_now - self.sites_last_update) > self.sites_update_time or self.sites_last_request is None:
-            print('time_now - self.sites_last_update is greater than self.sites_update_time')
 
             print('So call api')
             data = self.__call_api("sitelist/")
@@ -183,16 +177,8 @@ class Manager(object):
             # been set
             self.sites_last_update = time_now
         else:
-            print('time_now - self.sites_last_update is less than self.sites_update_time')
             sites = self.sites_last_request
-        print('sites is a ' + str(type(sites)))
-        print('There are ' + str(num_sites) + ' sites')
-        # Sometimes this function returns None
-        # The only ways I can see of this happening are:
-        # 1. The return statement never executes and the function returns None
-        # by default.
-        # 2. The else block is run while self.sites_last_request is still None
-        # (as initialised). This should never happen.
+
         return sites
 
     def get_nearest_site(self, longitude=False, latitude=False):

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -185,6 +185,11 @@ class Manager(object):
         print('sites is a ' + str(type(sites)))
         print('There are ' + str(num_sites) + ' sites')
         # Sometimes this function returns None
+        # The only ways I can see of this happening are:
+        # 1. The return statement never executes and the function returns None
+        # by default.
+        # 2. The else block is run while self.sites_last_request is still None
+        # (as initialised). This should never happen.
         return sites
 
     def get_nearest_site(self, longitude=False, latitude=False):

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -149,9 +149,9 @@ class Manager(object):
         print('time_now = ' + str(time_now))
         print('time_now - self.sites_last_update = ' + str(time_now - self.sites_last_update))
         num_sites = 0
-        if (time_now - self.sites_last_update) > self.sites_update_time:
+        if (time_now - self.sites_last_update) > self.sites_update_time or self.sites_last_request is None:
             print('time_now - self.sites_last_update is greater than self.sites_update_time')
-            self.sites_last_update = time_now
+
             print('So call api')
             data = self.__call_api("sitelist/")
             sites = list()
@@ -179,6 +179,9 @@ class Manager(object):
                 sites.append(site)
                 num_sites += 1
             self.sites_last_request = sites
+            # Only set self.sites_last_update once self.sites_last_request has
+            # been set
+            self.sites_last_update = time_now
         else:
             print('time_now - self.sites_last_update is less than self.sites_update_time')
             sites = self.sites_last_request

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -142,8 +142,17 @@ class Manager(object):
         """
         This function returns a list of Site object.
         """
-        if (time() - self.sites_last_update) > self.sites_update_time:
-            self.sites_last_update = time()
+
+        time_now = time()
+        print('sites_last_update = '+ str(self.sites_last_update))
+        print('sites_update_time = '+ str(self.sites_update_time))
+        print('time_now = ' + str(time_now))
+        print('time_now - self.sites_last_update = ' + str(time_now - self.sites_last_update))
+        num_sites = 0
+        if (time_now - self.sites_last_update) > self.sites_update_time:
+            print('time_now - self.sites_last_update is greater than self.sites_update_time')
+            self.sites_last_update = time_now
+            print('So call api')
             data = self.__call_api("sitelist/")
             sites = list()
             for jsoned in data['Locations']['Location']:
@@ -168,10 +177,14 @@ class Manager(object):
                 site.api_key = self.api_key
 
                 sites.append(site)
+                num_sites += 1
             self.sites_last_request = sites
         else:
+            print('time_now - self.sites_last_update is less than self.sites_update_time')
             sites = self.sites_last_request
-
+        print('sites is a ' + str(type(sites)))
+        print('There are ' + str(num_sites) + ' sites')
+        # Sometimes this function returns None
         return sites
 
     def get_nearest_site(self, longitude=False, latitude=False):
@@ -186,6 +199,9 @@ class Manager(object):
         nearest = False
         distance = None
         sites = self.get_all_sites()
+        print('sites is a ' + str(type(sites)))
+        # Sometimes there is a TypeError exception here: sites is None
+        # So, sometimes self.get_all_sites() has returned None.
         for site in sites:
             new_distance = \
                 self._distance_between_coords(

--- a/examples/current_weather/current_weather.py
+++ b/examples/current_weather/current_weather.py
@@ -11,14 +11,14 @@ conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
 # Get nearest site and print out its name
 site = conn.get_nearest_site(-0.124626, 51.500728)
-print site.name
+print(site.name)
 
 # Get a forecast for the nearest site
 forecast = conn.get_forecast_for_site(site.id, "3hourly")
 
 # Get the current timestep using now() and print out some info
 now = forecast.now()
-print now.weather.text
-print "%s%s%s" % (now.temperature.value,
-                  u'\xb0', #Unicode character for degree symbol
-                  now.temperature.units)
+print(now.weather.text)
+print("%s%s%s" % (now.temperature.value,
+                  '\xb0', #Unicode character for degree symbol
+                  now.temperature.units))

--- a/examples/postcodes_to_lat_lng/postcodes_to_lat_lng.py
+++ b/examples/postcodes_to_lat_lng/postcodes_to_lat_lng.py
@@ -17,14 +17,14 @@ longitude = result['geo']['lng']
 
 # Get nearest site and print out its name
 site = conn.get_nearest_site(longitude, latitude)
-print site.name
+print(site.name)
 
 # Get a forecast for the nearest site
 forecast = conn.get_forecast_for_site(site.id, "3hourly")
 
 # Get the current timestep using now() and print out some info
 now = forecast.now()
-print now.weather.text
-print "%s%s%s" % (now.temperature.value,
-                  u'\xb0', #Unicode character for degree symbol
-                  now.temperature.units)
+print(now.weather.text)
+print("%s%s%s" % (now.temperature.value,
+                  '\xb0', #Unicode character for degree symbol
+                  now.temperature.units))

--- a/examples/simple_forecast/simple_forecast.py
+++ b/examples/simple_forecast/simple_forecast.py
@@ -11,19 +11,19 @@ conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
 # Get nearest site and print out its name
 site = conn.get_nearest_site(-0.124626, 51.500728)
-print site.name
+print(site.name)
 
 # Get a forecast for the nearest site
 forecast = conn.get_forecast_for_site(site.id, "3hourly")
 
 # Loop through days and print date
 for day in forecast.days:
-    print "\n%s" % day.date
+    print("\n%s" % day.date)
 
     # Loop through time steps and print out info
     for timestep in day.timesteps:
-        print timestep.date
-        print timestep.weather.text
-        print "%s%s%s" % (timestep.temperature.value,
-                          u'\xb0', #Unicode character for degree symbol
-                          timestep.temperature.units)
+        print(timestep.date)
+        print(timestep.weather.text)
+        print("%s%s%s" % (timestep.temperature.value,
+                          '\xb0', #Unicode character for degree symbol
+                          timestep.temperature.units))

--- a/examples/text_forecast/text_forecast.py
+++ b/examples/text_forecast/text_forecast.py
@@ -11,14 +11,14 @@ conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 # Get all regions and print out their details
 regions = conn.regions.get_all_regions()
 for region in regions:
-    print (region.name, region.id, region.region)
+    print((region.name, region.id, region.region))
 
 # Get all forecasts for a specific region
 my_region = regions[0]
 forecast = conn.regions.get_raw_forecast(my_region.id)['RegionalFcst']
 
 # Print the forecast details
-print 'Forecast for {} (issued at {}):'.format(my_region.name, forecast['issuedAt'])
+print('Forecast for {} (issued at {}):'.format(my_region.name, forecast['issuedAt']))
 
 sections = forecast['FcstPeriods']['Period']
 for section in forecast['FcstPeriods']['Period']:
@@ -32,4 +32,4 @@ for section in forecast['FcstPeriods']['Period']:
         paragraph = content
 
     for line in paragraph:
-            print '{}\n{}\n'.format(line['title'], line['$'])
+            print('{}\n{}\n'.format(line['title'], line['$']))

--- a/examples/tube_bike/tube_bike.py
+++ b/examples/tube_bike/tube_bike.py
@@ -34,22 +34,22 @@ if (my_house_now.precipitation.value < 40 and \
         work_now.precipitation.value < 40 and \
         waterloo_status.description == "Good Service"):
 
-    print "Rain is unlikely and tube service is good, the decision is yours."
+    print("Rain is unlikely and tube service is good, the decision is yours.")
 
 # If it is going to rain then suggest the tube
 elif ((my_house_now.precipitation.value >= 40 or \
         work_now.precipitation.value >= 40) and \
         waterloo_status.description == "Good Service"):
 
-    print "Looks like rain, better get the tube"
+    print("Looks like rain, better get the tube")
 
 # If the tube isn't running then suggest cycling
 elif (my_house_now.precipitation.value < 40 and \
         work_now.precipitation.value < 40 and \
         waterloo_status.description != "Good Service"):
 
-    print "Bad service on the tube, cycling it is!"
+    print("Bad service on the tube, cycling it is!")
 
 # Else if both are bad then suggest cycling in the rain
 else:
-    print "The tube has poor service so you'll have to cycle, but it's raining so take your waterproofs."
+    print("The tube has poor service so you'll have to cycle, but it's raining so take your waterproofs.")

--- a/examples/umbrella/umbrella.py
+++ b/examples/umbrella/umbrella.py
@@ -14,7 +14,7 @@ conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
 # Get nearest site and print out its name
 site = conn.get_nearest_site(-0.124626, 51.500728)
-print site.name
+print(site.name)
 
 # Get a forecast for the nearest site
 forecast = conn.get_forecast_for_site(site.id, "3hourly")
@@ -27,6 +27,6 @@ for timestep in forecast.days[0].timesteps:
 
 # Print out the results
 if umbrella == True:
-    print "Looks like rain! Better take an umbrella."
+    print("Looks like rain! Better take an umbrella.")
 else:
-    print "Don't worry you don't need an umbrella today."
+    print("Don't worry you don't need an umbrella today.")

--- a/examples/washing/washing.py
+++ b/examples/washing/washing.py
@@ -24,7 +24,7 @@ conn = datapoint.Manager(api_key="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
 # Get nearest site and print out its name
 site = conn.get_nearest_site(-0.124626, 51.500728)
-print site.name
+print(site.name)
 
 # Get a forecast for the nearest site
 forecast = conn.get_forecast_for_site(site.id, "daily")
@@ -51,10 +51,10 @@ for day in forecast.days:
 
 # If best_day is still None then there are no good days
 if best_day is None:
-    print "Better use the tumble dryer"
+    print("Better use the tumble dryer")
 
 # Otherwise print out the day
 else:
     # Get the day of the week from the datetime object
     best_day_formatted = datetime.strftime(best_day, "%A")
-    print "%s is the best day with a score of %s" % (best_day_formatted, best_day_score)
+    print("%s is the best day with a score of %s" % (best_day_formatted, best_day_score))


### PR DESCRIPTION
It is possible for the list returned from get_all_sites to be None. This pull request ensures that the list of sites is updated if the stored sites are None, and moves the recording of the check after the check is done.

This request includes pull requests #41 and #42. #41 is included so forecast.now() works properly, and #42  was a mistake.