### PR TITLE
Timeout

### DIFF
--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -104,6 +104,7 @@ class Manager(object):
         # The value of 1 second is entirely arbitrary and may change.
         # Could expose to users in the functions which need to call the api.
         req = requests.get(url, params=payload, timeout=1)
+        # requests.Session has the same features but allows retrying.
 
         try:
             data = req.json()

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -99,7 +99,12 @@ class Manager(object):
         payload = {'key': self.api_key}
         payload.update(params)
         url = "%s/%s" % (API_URL, path)
-        req = requests.get(url, params=payload)
+
+        # Add a timeout to the request.
+        # The value of 1 second is entirely arbitrary and may change.
+        # Could expose to users in the functions which need to call the api.
+        req = requests.get(url, params=payload, timeout=1)
+
         try:
             data = req.json()
         except ValueError:


### PR DESCRIPTION
This pull request adds a timeout of 1 second to the api call. The choice of 1 second is entirely arbitrary.

I have not yet looked at the possibility of retrying the connection.