### PR TITLE
Update travis to use latest requests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
 language: python
 sudo: false
+dist: xenial
 python:
-  - '2.6'
   - '2.7'
-  - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
 matrix:
   include:
-    - python: '3.7'
-      dist: xenial
+    - python: '2.6'
+      dist: trusty
+    - python: '3.3'
+      dist: trusty
 env:
 - secure: PEOM40L5TK78GFQyt2I2PgOFf8QYGcP0YZmgMhacuKnCI0Lr3wztXucWtxeVpXeuDDe12d349FumQrg6ard8T69ZZYe25eJ5lR9ZMyVOzFJ9Ew3XhoEgWBgKFRNjEkhFU+/reYWRBkYHyFImLe9d8wq1I2UMQ6z2189PLKfBtIg=
 install:
 - pip install .
-- pip install -r requirements.txt
+- if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements_26.txt; else pip install -r requirements.txt; fi
 script:
 - nosetests -w tests/unit
 - if [[ "$API_KEY" != "" ]]; then nosetests -w tests/integration; fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.3.0
+requests==2.21.0
 appdirs
 pytz

--- a/requirements_26.txt
+++ b/requirements_26.txt
@@ -1,0 +1,3 @@
+requests==2.19.1
+appdirs
+pytz


### PR DESCRIPTION
Update travis requirements to use requests 2.21.0 from 2.3.0. This has the potential to break something.