### PR TITLE
Require that location for forecast is within 30km of site

### DIFF
--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -265,6 +265,12 @@ class Manager(object):
             if ((distance == None) or (new_distance < distance)):
                 distance = new_distance
                 nearest = site
+
+        # If the nearest site is more than 30km away, raise an error
+
+        if distance > 30:
+            raise APIException("There is no site within 30km.")
+
         return nearest
 
     def get_forecast_for_site(self, site_id, frequency="daily"):

--- a/docs/locations.rst
+++ b/docs/locations.rst
@@ -6,9 +6,7 @@ There are around 6000 sites available for forecasts, and around 150 sites availa
 Forecast sites
 --------------
 
-The locations of the sites available for which forecasts are shown on the map below.
-
-.. Forecasts are restricted to locations within 30 km of the nearest site. This includes all of the United Kingdom. Most of the UK is within 10 km of the nearest site.
+The locations of the sites available for which forecasts are shown on the map below. Forecasts are restricted to locations within 30 km of the nearest site. This includes all of the United Kingdom. Most of the UK is within 10 km of the nearest site.
 
 .. figure:: forecast_sites_map.png
    :alt: Map showing the locations of the sites for which forecasts are available.


### PR DESCRIPTION
This adds code to require that the location for which a forecast is requested is within 30km of the nearest site. Fixes #15, #37 and #71.