### PR TITLE
Raise an error if the nearest observation site is more than 20km away

### DIFF
--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -442,6 +442,11 @@ class Manager(object):
             if ((distance == None) or (new_distance < distance)):
                 distance = new_distance
                 nearest = site
+
+        # If the nearest site is more than 20km away, raise an error
+        if distance > 20:
+            raise APIException("There is no site within 30km.")
+
         return nearest
 
 


### PR DESCRIPTION
This requires the location for which an observation is requested to be within 20 km of the nearest site. This excludes some of the UK, but the observations are unlikely to be reliable if the distance is extended to cover the whole of the UK