### PR TITLE
Rename forecast site functions

### DIFF
--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from time import time
 from math import radians, cos, sin, asin, sqrt
 import pytz
+from warnings import warn
 
 import requests
 
@@ -195,6 +196,15 @@ class Manager(object):
         else:
             return 'EX'
 
+    def get_all_sites(self):
+        """
+        Deprecated. This function returns a list of Site object.
+        """
+        warning_message = 'This function is deprecated. Use get_forecast_sites() instead'
+        warn(warning_message, DeprecationWarning, stacklevel=2)
+
+        return self.get_forecast_sites()
+
     def get_forecast_sites(self):
         """
         This function returns a list of Site object.
@@ -235,6 +245,16 @@ class Manager(object):
             sites = self.forecast_sites_last_request
 
         return sites
+
+    def get_nearest_site(self, latitude=None,  longitude=None):
+        """
+        Deprecated. This function returns nearest Site object to the specified
+        coordinates.
+        """
+        warning_message = 'This function is deprecated. Use get_nearest_forecast_site() instead'
+        warn(warning_message, DeprecationWarning, stacklevel=2)
+
+        return self.get_nearest_site(latitude, longitude)
 
     def get_nearest_forecast_site(self, latitude=None,  longitude=None):
         """

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -251,7 +251,7 @@ class Manager(object):
 
         nearest = False
         distance = None
-        sites = self.get_all_sites()
+        sites = self.get_forecast_sites()
         # Sometimes there is a TypeError exception here: sites is None
         # So, sometimes self.get_all_sites() has returned None.
         for site in sites:

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -195,7 +195,7 @@ class Manager(object):
         else:
             return 'EX'
 
-    def get_all_sites(self):
+    def get_forecast_sites(self):
         """
         This function returns a list of Site object.
         """
@@ -236,7 +236,7 @@ class Manager(object):
 
         return sites
 
-    def get_nearest_site(self, latitude=None,  longitude=None):
+    def get_nearest_forecast_site(self, latitude=None,  longitude=None):
         """
         This function returns the nearest Site object to the specified
         coordinates.

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -93,9 +93,9 @@ class Manager(object):
 
         # The list of sites changes infrequently so limit to requesting it
         # every hour.
-        self.sites_last_update = 0
-        self.sites_last_request = None
-        self.sites_update_time = 3600
+        self.forecast_sites_last_update = 0
+        self.forecast_sites_last_request = None
+        self.forecast_sites_update_time = 3600
 
         self.observation_sites_last_update = 0
         self.observation_sites_last_request = None
@@ -201,7 +201,7 @@ class Manager(object):
         """
 
         time_now = time()
-        if (time_now - self.sites_last_update) > self.sites_update_time or self.sites_last_request is None:
+        if (time_now - self.forecast_sites_last_update) > self.forecast_sites_update_time or self.forecast_sites_last_request is None:
 
             data = self.__call_api("sitelist/")
             sites = list()
@@ -227,12 +227,12 @@ class Manager(object):
                 site.api_key = self.api_key
 
                 sites.append(site)
-            self.sites_last_request = sites
+            self.forecast_sites_last_request = sites
             # Only set self.sites_last_update once self.sites_last_request has
             # been set
-            self.sites_last_update = time_now
+            self.forecast_sites_last_update = time_now
         else:
-            sites = self.sites_last_request
+            sites = self.forecast_sites_last_request
 
         return sites
 

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -254,7 +254,7 @@ class Manager(object):
         warning_message = 'This function is deprecated. Use get_nearest_forecast_site() instead'
         warn(warning_message, DeprecationWarning, stacklevel=2)
 
-        return self.get_nearest_site(latitude, longitude)
+        return self.get_nearest_forecast_site(latitude, longitude)
 
     def get_nearest_forecast_site(self, latitude=None,  longitude=None):
         """

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -47,7 +47,7 @@ We can simply request a Site Object like so:
 
 ::
 
-   site = conn.get_nearest_site(51.500728, -0.124626)
+   site = conn.get_nearest_forecast_site(51.500728, -0.124626)
 
 For now we’re just going to use this object to get us our forecast but
 you’ll find more information about what the Site Object contains later.

--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -33,17 +33,17 @@ sites_update_time   int
 Methods
 ^^^^^^^
 
-get_all_sites()
+get_forecast_sites()
 '''''''''''''''
 
-Returns a list of all available sites.
+Returns a list of available forecast sites.
 
 - returns: list of Site objects
 
-get_nearest_site(latitude=False, longitude=False)
+get_nearest_forecast_site(latitude=False, longitude=False)
 '''''''''''''''''''''''''''''''''''''''''''''''''
 
-Returns the nearest Site object to the specified coordinates.
+Returns the nearest Site object to the specified coordinates which can provide a forecast.
 
 - param latitude: int or float
 - param longitude: int or float

--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -20,15 +20,18 @@ The object which stores your API key and has methods to access the API.
 Attributes
 ^^^^^^^^^^
 
-==================  ====================
-attribute           type
-------------------  --------------------
-api_key             string
-call_response       dict
-sites_last_update   float
-sites_last_request  list of Site objects
-sites_update_time   int
-==================  ====================
+==============================  ====================
+attribute                       type
+------------------------------  --------------------
+api_key                         string
+call_response                   dict
+forecast_sites_last_update      float
+forecast_sites_last_request     list of Site objects
+forecast_sites_update_time      int
+observation_sites_last_update   float
+observation_sites_last_request  list of Site objects
+observation_sites_update_time   int
+==============================  ====================
 
 Methods
 ^^^^^^^

--- a/tests/integration/manager_test.py
+++ b/tests/integration/manager_test.py
@@ -11,16 +11,16 @@ class TestManager:
         self.manager = datapoint.Manager(api_key=os.environ['API_KEY'])
 
     def test_site(self):
-        site = self.manager.get_nearest_site(latitude=51.500728, longitude=-0.124626)
+        site = self.manager.get_nearest_forecast_site(latitude=51.500728, longitude=-0.124626)
         assert site.name.upper() == 'HORSEGUARDS PARADE'
 
-    def test_get_all_sites(self):
-        sites = self.manager.get_all_sites()
+    def test_get_forecast_sites(self):
+        sites = self.manager.get_forecast_sites()
         assert isinstance(sites, list)
         assert sites
 
     def test_get_daily_forecast(self):
-        site = self.manager.get_nearest_site(latitude=51.500728, longitude=-0.124626)
+        site = self.manager.get_nearest_forecast_site(latitude=51.500728, longitude=-0.124626)
         forecast = self.manager.get_forecast_for_site(site.id, 'daily')
         assert isinstance(forecast, datapoint.Forecast.Forecast)
         assert forecast.continent.upper() == 'EUROPE'
@@ -62,7 +62,7 @@ class TestManager:
                     assert 0 < int(timestep.uv.value) < 20
 
     def test_get_3hour_forecast(self):
-        site = self.manager.get_nearest_site(latitude=51.500728, longitude=-0.124626)
+        site = self.manager.get_nearest_forecast_site(latitude=51.500728, longitude=-0.124626)
         forecast = self.manager.get_forecast_for_site(site.id, '3hourly')
         assert isinstance(forecast, datapoint.Forecast.Forecast)
         assert forecast.continent.upper() == 'EUROPE'


### PR DESCRIPTION
Rename forecast site functions to include the word forecast. This removes ambiguity about what the functions do: instead of `get_all_sites()` the function is `get_forecast_sites()` etc..

This is a breaking change so should be included in a version change.

Fixes #75 