### PR TITLE
Store version number using git tag only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ build/
 develop-eggs/
 dist/
 eggs/
+.eggs/
 lib/
 lib64/
 parts/

--- a/datapoint/__init__.py
+++ b/datapoint/__init__.py
@@ -1,14 +1,21 @@
 """Datapoint API to retrieve Met Office data"""
 
-__version__ = "0.7.0"
+#__version__ = "0.7.0"
 __author__ = "Jacob Tomlinson"
 __author_email__ = "jacob.tomlinson@metoffice.gov.uk"
 
 import os.path
+from pkg_resources import get_distribution, DistributionNotFound
 
 from datapoint.Manager import Manager
 import datapoint.profile
 
+# This block is from the setuptools_scm README
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # Package is not installed
+    pass
 
 def connection(profile_name='default', api_key=None):
     """Connect to DataPoint with the given API key profile name."""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,8 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+# -- Other imports -----------------------------------------------------------
+from pkg_resources import get_distribution
 
 # -- Project information -----------------------------------------------------
 
@@ -23,11 +25,11 @@ project = 'datapoint-python'
 copyright = '2014, Jacon Tomlinson'
 author = 'Jacob Tomlinson'
 
-# The short X.Y version
-version = '0.7'
 # The full version, including alpha/beta/rc tags
-release = '0.7.0'
+release = get_distribution('datapoint').version
 
+# The short X.Y version
+version = '.'.join(release.split('.')[:2])
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,15 @@
 from setuptools import setup
 
 setup(name='datapoint',
-      version='0.7.0',
       install_requires=[
           "requests >= 2.20.0",
           "appdirs",
           "pytz",
       ],
+      use_scm_version=True,
+      setup_requires=[
+          'setuptools_scm',
+          ],
       description='Python interface to the Met Office\'s Datapoint API',
       long_description_content_type='text/x-rst',
       long_description='''


### PR DESCRIPTION
This PR uses `setuptools_scm` to get the version number from the git tag. Resolves #82.